### PR TITLE
Fixed ServiceProvider not found issue while installing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rippleworks/laravel-mojo",
+    "name": "lubusin/laravel-mojo",
     "description": "Laravel Mojo provides an expressive, fluent interface to Instamojo's payment and refund services.",
     "keywords": ["laravel", "instamojo", "package"],
     "license": "MIT",	
@@ -7,10 +7,6 @@
         {
             "name": "Harish Toshniwal",
             "email": "harish@lubus.in"
-        },
-        {
-            "name": "Nilesh PS",
-            "email": "nps17thatsme@gmail.com"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lubusin/laravel-mojo",
+    "name": "rippleworks/laravel-mojo",
     "description": "Laravel Mojo provides an expressive, fluent interface to Instamojo's payment and refund services.",
     "keywords": ["laravel", "instamojo", "package"],
     "license": "MIT",	
@@ -7,6 +7,10 @@
         {
             "name": "Harish Toshniwal",
             "email": "harish@lubus.in"
+        },
+        {
+            "name": "Nilesh PS",
+            "email": "nps17thatsme@gmail.com"
         }
     ],
     "autoload": {
@@ -26,7 +30,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Lubusin\\Mojo\\ServiceProvider"
+                "Lubusin\\Mojo\\MojoServiceProvider"
             ]
         }
     }


### PR DESCRIPTION
In the composer.json file, it should be **_Lubusin\Mojo\MojoServiceProvider_** .  There is no 
**_Lubusin\Mojo\ServiceProvider_** class.  As a result, laravel could not bootstrap properly because of missing/unknown object. I have corrected this issue. Please pull the change.